### PR TITLE
feat(hook): add Hadolint support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,3 +23,11 @@ repos:
     hooks:
       - id: prettier
         name: Prettier
+
+  - repo: local
+    hooks:
+      - id: dockerfile-provides-entrypoint
+        name: hadolint
+        language: docker_image
+        entry: --entrypoint hadolint hadolint/hadolint:latest-debian
+        files: Dockerfile


### PR DESCRIPTION
Add [Hadolint](https://github.com/hadolint/hadolint) as a pre-commit hook. Hadolint lints `Dockerfile`s and in-line Bash commands, and helps build Docker images that follow best practices.

[![pre-commit - Hadolint](https://asciinema.org/a/335409.svg)](https://asciinema.org/a/335409)